### PR TITLE
Adding skip function to morgan

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,14 @@ const api = require('./api');
 
 const app = express();
 
-app.use(morgan('dev'));
+app.use(morgan('dev', {
+  skip: (req, res) => {
+    if (process.env.NODE_ENV !== 'development') {
+      return res.statusCode < 400;
+    }
+    return false;
+  }
+}));
 app.use(helmet());
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
Adding skip function to morgan which will run when the NODE_ENV is not development
This is to prevent a spam of 2xx and 3xx status' in the logs in production
Unlike 4xx and 5xx, 2xx and 3xx don't add much value